### PR TITLE
Add functionality to override branch

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 sinai_version: 0.0.1-SNAPSHOT
 solr_server: "http%3A%2F%2Flocalhost%3A8983%2Fsolr%2Fsinai"
+sinai_github_branch: {{ secret_files[sinai_env]['github_branch'] }}

--- a/tasks/jenkinsdeploy.yml
+++ b/tasks/jenkinsdeploy.yml
@@ -1,6 +1,6 @@
 ---
 - name: Download Sinai Artifact
-  shell: wget http://build-artifacts.library.ucla.edu/sinai-web/{{ secret_files[sinai_env]['github_branch'] }}/{{ secret_files[sinai_env]['sinai_vers'] }} -O /opt/sinai/{{ secret_files[sinai_env]['sinai_vers'] }}
+  shell: wget http://build-artifacts.library.ucla.edu/sinai-web/{{ sinai_github_branch }}/{{ secret_files[sinai_env]['sinai_vers'] }} -O /opt/sinai/{{ secret_files[sinai_env]['sinai_vers'] }}
 
 - name: Set file attributes for Jar file
   file: path=/opt/sinai/{{ secret_files[sinai_env]['sinai_vers'] }} owner=sinai mode=0600 state=file


### PR DESCRIPTION
*Summary*
This PR allows Jenkins build to download different artifacts for each environment build. The `sinai_github_branch` var overrides in Jenkins via an external ansible variable call.